### PR TITLE
Fixed code logic.

### DIFF
--- a/factoring.rb
+++ b/factoring.rb
@@ -8,7 +8,6 @@ x = 2
 		elsif num % x == 0
 			num /= x
 			factors << x
-			x += 1
 			x = 2
 		else
 			x += 1

--- a/factoring.rb
+++ b/factoring.rb
@@ -1,7 +1,7 @@
 def factor(num)
 factors = Array.new
 x = 2
-	until num != 1
+	until num == 1
 		if num < 0
 			factors << -1
 			num *= -1


### PR DESCRIPTION
`until n != 1` causes immediate termination, resulting in the prime factors never being found.
